### PR TITLE
Ensure sword follows player movement with bounds

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,12 +94,34 @@ class SwordGameApp(tk.Tk):
         self.after(DURATION_MS, self.end_game)
 
     def move_player(self, dx, dy):
-        # update player base position within bounds
-        self.base_x = max(0, min(WIDTH, self.base_x + dx))
-        self.base_y = max(0, min(HEIGHT, self.base_y + dy))
-        self.canvas.move(self.player, dx, dy)
-        x2, y2 = self.canvas.coords(self.sword)[2:]
-        self.canvas.coords(self.sword, self.base_x, self.base_y, x2, y2)
+        """Move the player and keep the sword aligned.
+
+        The player's base position is restricted to stay fully within the
+        canvas. The sword's tip should maintain its relative position to the
+        player as the player moves.
+        """
+
+        # Calculate new base position with margins so the whole player stays
+        # inside the canvas bounds.
+        margin = 10
+        old_x, old_y = self.base_x, self.base_y
+        self.base_x = max(margin, min(WIDTH - margin, self.base_x + dx))
+        self.base_y = max(margin, min(HEIGHT - margin, self.base_y + dy))
+
+        # Determine the actual distance moved (may be less than dx/dy at edges)
+        actual_dx = self.base_x - old_x
+        actual_dy = self.base_y - old_y
+        self.canvas.move(self.player, actual_dx, actual_dy)
+
+        # Move sword tip by the same amount to keep orientation
+        x1, y1, x2, y2 = self.canvas.coords(self.sword)
+        self.canvas.coords(
+            self.sword,
+            self.base_x,
+            self.base_y,
+            x2 + actual_dx,
+            y2 + actual_dy,
+        )
 
     def move_sword(self, event):
         # update sword line to point towards mouse

--- a/tests/test_move_player.py
+++ b/tests/test_move_player.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the Python path for imports.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+
+class DummyCanvas:
+    def __init__(self):
+        self.coords_map = {}
+        self.next_id = 1
+
+    def create_oval(self, x1, y1, x2, y2, **kwargs):
+        item = self.next_id
+        self.next_id += 1
+        self.coords_map[item] = [x1, y1, x2, y2]
+        return item
+
+    def create_line(self, x1, y1, x2, y2, **kwargs):
+        item = self.next_id
+        self.next_id += 1
+        self.coords_map[item] = [x1, y1, x2, y2]
+        return item
+
+    def move(self, item, dx, dy):
+        coords = self.coords_map[item]
+        self.coords_map[item] = [coords[0] + dx, coords[1] + dy,
+                                 coords[2] + dx, coords[3] + dy]
+
+    def coords(self, item, *new_coords):
+        if new_coords:
+            self.coords_map[item] = list(new_coords)
+        return list(self.coords_map[item])
+
+
+def make_app():
+    app = object.__new__(main.SwordGameApp)
+    app.canvas = DummyCanvas()
+    app.base_x = main.WIDTH // 2
+    app.base_y = main.HEIGHT // 2
+    app.player = app.canvas.create_oval(
+        app.base_x - 10, app.base_y - 10, app.base_x + 10, app.base_y + 10,
+        fill="blue",
+    )
+    app.sword = app.canvas.create_line(
+        app.base_x, app.base_y, app.base_x, app.base_y - 100,
+        width=5, fill="gray",
+    )
+    return app
+
+
+def test_move_player_updates_sword():
+    app = make_app()
+    app.move_player(20, -20)
+    assert app.base_x == main.WIDTH // 2 + 20
+    assert app.base_y == main.HEIGHT // 2 - 20
+    x1, y1, x2, y2 = app.canvas.coords(app.sword)
+    assert (x2, y2) == (app.base_x, app.base_y - 100)
+
+
+def test_move_player_stays_within_bounds():
+    app = make_app()
+    app.move_player(-1000, -1000)
+    assert app.base_x == 10
+    assert app.base_y == 10
+    assert app.canvas.coords(app.sword) == [10, 10, 10, -90]


### PR DESCRIPTION
## Summary
- Keep player fully inside canvas and move sword tip with player
- Add regression tests for player movement and sword alignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76c3f240c832a9fcaf8468564482a