### PR TITLE
Initialize sword state before spawning fruits

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,10 +132,10 @@ class SwordGameApp(tk.Tk):
 
         # list of active fruits
         self.fruits = []
-        self.spawn_fruit()
 
-        # sword initially inactive; timer countdown
+        # sword initially inactive; ensure defined before spawning fruits
         self.sword_active = False
+        self.spawn_fruit()
         self.remaining_ms = DURATION_MS
         self.update_timer()
 


### PR DESCRIPTION
## Summary
- Ensure `sword_active` is initialized before any fruits spawn
- Prevent `AttributeError` when checking sword hits during early fruit spawns

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f2079220832abde190b0ab834928