### PR TITLE
Add colored enemies with scaling spawn probabilities

### DIFF
--- a/tests/test_fruit.py
+++ b/tests/test_fruit.py
@@ -22,3 +22,29 @@ def test_fruit_move_uses_speed():
     f.move()
     after = canvas.coords(f.id)
     assert after[1] - before[1] == f.speed
+
+
+def test_spawn_probabilities_level1():
+    probs = main.spawn_probabilities(1)
+    assert probs == {"black": 1, "red": 3, "purple": 5, "green": 91}
+
+
+def test_spawn_probabilities_cap():
+    probs = main.spawn_probabilities(30)
+    assert probs["green"] == 0
+    assert probs["black"] == 30
+    assert probs["red"] == 32
+    assert probs["purple"] == 38
+
+
+def test_fruit_requires_multiple_hits():
+    canvas = DummyCanvas()
+    app = object.__new__(main.SwordGameApp)
+    app.canvas = canvas
+    app.sword = canvas.create_line(0, 0, 0, 0)
+    app.sword_active = True
+    fruit = main.Fruit(canvas, level=1, x=0, y=0, color="purple", hits=2)
+    assert not app.check_sword_hit(fruit)
+    assert fruit.hp == 1
+    assert app.check_sword_hit(fruit)
+    assert fruit.hp == 0

--- a/tests/test_move_player.py
+++ b/tests/test_move_player.py
@@ -32,6 +32,13 @@ class DummyCanvas:
             self.coords_map[item] = list(new_coords)
         return list(self.coords_map[item])
 
+    def find_overlapping(self, x1, y1, x2, y2):
+        overlapping = []
+        for item, (ix1, iy1, ix2, iy2) in self.coords_map.items():
+            if not (ix2 <= x1 or ix1 >= x2 or iy2 <= y1 or iy1 >= y2):
+                overlapping.append(item)
+        return overlapping
+
 
 def make_app():
     app = object.__new__(main.SwordGameApp)


### PR DESCRIPTION
## Summary
- Reduce level duration to one minute
- Introduce multi-hit colored enemies with level-dependent spawn chances
- Extend tests for spawn distribution and hit mechanics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b899fe0f78832a8ff0e8c472c4f454