### PR TITLE
Spawn finish-point fruits that chase the player

### DIFF
--- a/tests/test_fruit.py
+++ b/tests/test_fruit.py
@@ -17,16 +17,19 @@ def test_fruit_speed_increases_with_level():
 
 def test_fruit_move_uses_speed():
     canvas = DummyCanvas()
-    f = main.Fruit(canvas, level=2, x=50, y=0)
+    f = main.Fruit(canvas, level=2, x=0, y=0)
     before = canvas.coords(f.id)
-    f.move()
+    f.move(100, 0)
     after = canvas.coords(f.id)
-    assert after[1] - before[1] == f.speed
+    dx = after[0] - before[0]
+    dy = after[1] - before[1]
+    dist = (dx ** 2 + dy ** 2) ** 0.5
+    assert abs(dist - f.speed) < 1e-6
 
 
 def test_spawn_probabilities_level1():
     probs = main.spawn_probabilities(1)
-    assert probs == {"black": 1, "red": 3, "purple": 5, "orange": 2, "green": 89}
+    assert probs == {"black": 1, "red": 3, "purple": 5, "green": 91}
 
 
 def test_spawn_probabilities_cap():
@@ -58,10 +61,40 @@ def test_fruit_has_sword_icon():
 
 def test_fruit_icon_moves_with_fruit():
     canvas = DummyCanvas()
-    f = main.Fruit(canvas, level=1, x=50, y=0)
+    f = main.Fruit(canvas, level=1, x=0, y=0)
     before = [canvas.coords(i)[:] for i in f.icon_ids]
-    f.move()
+    f.move(50, 0)
     after = [canvas.coords(i)[:] for i in f.icon_ids]
     for b, a in zip(before, after):
-        assert a[1] - b[1] == f.speed
-        assert a[3] - b[3] == f.speed
+        dx = a[0] - b[0]
+        dy = a[1] - b[1]
+        dist = (dx ** 2 + dy ** 2) ** 0.5
+        assert abs(dist - f.speed) < 1e-6
+        dx2 = a[2] - b[2]
+        dy2 = a[3] - b[3]
+        dist2 = (dx2 ** 2 + dy2 ** 2) ** 0.5
+        assert abs(dist2 - f.speed) < 1e-6
+
+
+class DummyLabel:
+    def config(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_fruit_collision_loses_life():
+    app = object.__new__(main.SwordGameApp)
+    app.canvas = DummyCanvas()
+    app.base_x = 50
+    app.base_y = 50
+    app.player = app.canvas.create_oval(40, 40, 60, 60)
+    app.sword = app.canvas.create_line(0, 0, 0, 0)
+    app.sword_active = False
+    app.lives = 2
+    app.lives_label = DummyLabel()
+    app.fruits = []
+    app.running = True
+    fruit = main.Fruit(app.canvas, level=1, x=50, y=50)
+    app.fruits.append(fruit)
+    app.move_fruit(fruit)
+    assert app.lives == 1
+    assert fruit not in app.fruits


### PR DESCRIPTION
## Summary
- Make fruits spawn from the level's finish tile and pursue the player.
- Fruits now track the player and remove a life on contact.
- Adjust unit tests for new fruit behaviour and add collision test.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b997313a48832a8c7f1db0cbd1cba9